### PR TITLE
Add Titles to Convoy and Virtfusion Features Pages, and Display Convoy in Sidebar

### DIFF
--- a/content/features/Convoy/index.md
+++ b/content/features/Convoy/index.md
@@ -1,6 +1,7 @@
 ---
 toc: true
 ---
+# Convoy
 
 ## Overview
 

--- a/content/features/Virtfusion/index.md
+++ b/content/features/Virtfusion/index.md
@@ -1,6 +1,7 @@
 ---
 toc: true
 ---
+# Virtfusion
 
 ## Overview
 

--- a/data/sidebar.yml
+++ b/data/sidebar.yml
@@ -15,6 +15,7 @@
     - title: Stripe
     - title: PayPal
     - title: Enhance
+    - title: Convoy
 - title: Customization
   slug: customization
   pages:


### PR DESCRIPTION
This pull request addresses two main points:

Sidebar Update: The Convoy documentation was already present but not visible in the sidebar. I have updated the sidebar configuration to ensure the Convoy docs are now accessible.

Title Consistency: I added titles to the Convoy and Virtfusion features pages to maintain consistency across the documentation.