### PR TITLE
docs: hardcode v0.9.5 paymenter version in installation

### DIFF
--- a/content/docs/getting-started/installation.md
+++ b/content/docs/getting-started/installation.md
@@ -85,7 +85,7 @@ Clone our repo from Github to your server:
 ```
 mkdir /var/www/paymenter
 cd /var/www/paymenter
-curl -Lo paymenter.tar.gz https://github.com/paymenter/paymenter/releases/latest/download/paymenter.tar.gz
+curl -Lo paymenter.tar.gz https://github.com/Paymenter/Paymenter/releases/download/v0.9.5/paymenter.tar.gz
 tar -xzvf paymenter.tar.gz
 chmod -R 755 storage/* bootstrap/cache/
 ```


### PR DESCRIPTION
The old documentation tells the users to download the latest release of Paymenter from GitHub however, now Paymenter v1 Alpha is out, so it would be better to hardcode the latest release of 0.x series in the old documentation.