### PR TITLE
Update OAuth.md

### DIFF
--- a/docs/guides/OAuth.md
+++ b/docs/guides/OAuth.md
@@ -10,7 +10,7 @@ First locate to [Discord Developer Page](https://discord.dev) and click on New a
 
 Name your application and hit create.
 After that navigate to OAuth2 and click on Add Redirect
-and add Paymenter OAuth callback URL (<https://yourdomain.here/login/discord/callback>).
+and add Paymenter OAuth callback URL (<https://yourdomain.here/oauth/discord/callback>).
 After that click on Reset Secret, The page should look like this.
 
 ![discord_discorddev2](/assets/images/guides/OAuth/discord_discorddevfull.png)
@@ -34,7 +34,7 @@ Click on OAuth Apps and click on Register a new application
 
 ![github_2](/assets/images/guides/OAuth/github_2.png)
 
-Create a new application with the callback (<https://yourdomain.here/login/github/callback>)
+Create a new application with the callback (<https://yourdomain.here/oauth/github/callback>)
 Should look something like this.
 
 ![github_3](/assets/images/guides/OAuth/github_3.png)
@@ -92,7 +92,7 @@ After that go back to Credentials and click on Create credentials --> OAuth clie
 
 ![google_9](/assets/images/guides/OAuth/google_3.png)
 
-Select Web application and for Authorized redirect URIs put (<https://yourdomain.here/login/google/callback>)
+Select Web application and for Authorized redirect URIs put (<https://yourdomain.here/oauth/google/callback>)
 Should look like this.
 
 ![google_10](/assets/images/guides/OAuth/google_10.png)


### PR DESCRIPTION
Added correct endpoints for the callback from login

Here is the domain from discord:
https://discord.com/oauth2/authorize?client_id=1279808297846833215&redirect_uri=https%3A%2F%2Fcptcr.shop%2Foauth%2Fdiscord%2Fcallback&scope=identify+email&response_type=code&state=abbCvY55wcfU9xxSzX9IOStVtewLnslTfaSIkxLB&prompt=none

In this URL you find cptcr.shop%2Foauth%2Fdiscord%2Fcallback which tells us that the correct endpoint will be /oauth/discord/callback

I assume that this is on all login methods.