### PR TITLE
Update getCheckoutConfig

### DIFF
--- a/development/extensions/server.md
+++ b/development/extensions/server.md
@@ -29,6 +29,8 @@ public function getProductConfig($values = [])
 Shown to the user when they are checking out.
 
 ```php
+use App\Models\Product;
+
 public function getCheckoutConfig(Product $product)
 {
     return [

--- a/development/extensions/server.md
+++ b/development/extensions/server.md
@@ -34,17 +34,15 @@ use App\Models\Product;
 public function getCheckoutConfig(Product $product)
 {
     return [
-        'fields' => [
-            [
-                'name' => 'location',
-                'label' => 'Location',
-                'type' => 'select',
-                'required' => true,
-                'options' => [
-                    '1' => 'Location 1',
-                    '2' => 'Location 2',
-                ],
-            ]
+        [
+            'name' => 'location',
+            'label' => 'Location',
+            'type' => 'select',
+            'required' => true,
+            'options' => [
+                '1' => 'Location 1',
+                '2' => 'Location 2',
+            ],
         ]
     ];
 }


### PR DESCRIPTION
Add import because because laravel thinks Product is a seperate object.

`Argument #1 ($product) must be of type Paymenter\Extensions\Servers\Pelican\Product, App\Models\Product given`

And removed `fields` wrap because it's not expected there.