### PR TITLE
Permission error on install

### DIFF
--- a/docs/installation/install.md
+++ b/docs/installation/install.md
@@ -88,6 +88,8 @@ Granting the right permissions to the folder:
 
 ```bash
 chmod -R 755 storage/* bootstrap/cache/
+chown -R www-data:www-data /var/www/paymenter
+
 ```
 
 ## Downloading packages


### PR DESCRIPTION
Laravel trows a permission denied because root is the file owner. This fixes that