### PR TITLE
docs(oauth): fix typo in endpoint path (/api/oauth/me → /api/me)

### DIFF
--- a/development/OAuth.md
+++ b/development/OAuth.md
@@ -36,7 +36,7 @@ You can exchange this code for an access token by making a POST request to the f
 Then to get the user's information, you can make a GET request to the following URL:
 
 ```
-<your_paymenter_url>/api/oauth/me
+<your_paymenter_url>/api/me
 ```
 
 You need to pass the access token in the Authorization header.


### PR DESCRIPTION
As stated in the [routes](https://github.com/Paymenter/Paymenter/blob/52ae320aa97ce8b11f73222fe1b9d00f11725ca4/routes/api.php#L20), the endpoint `/api/oauth/me` does not exist.